### PR TITLE
fix: correct bucket ownership controls bug

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "aws_s3_bucket" "app_bucket" {
 resource "aws_s3_bucket_ownership_controls" "app_bucket_acl_ownership" {
   bucket = aws_s3_bucket.app_bucket.id
   rule {
-    object_ownership = "BucketOwnerPreferred"
+    object_ownership = "ObjectWriter"
   }
 }
 


### PR DESCRIPTION
The resource `aws_s3_buck_ownership_controls` needs to be set to `ObjectWriter` to enable ACLs to be created for a new bucket.

See: https://stackoverflow.com/questions/76049290/error-accesscontrollistnotsupported-when-trying-to-create-a-bucket-acl-in-aws