### PR TITLE
fix: handle those very weird filenames

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,13 +71,17 @@ locals {
 }
 
 resource "aws_s3_object" "app_bucket_source" {
-  for_each     = fileset(var.source_files, "**")
-  bucket       = aws_s3_bucket.app_bucket.id
-  key          = each.value
-  source       = "${var.source_files}/${each.value}"
-  etag         = filemd5("${var.source_files}/${each.value}")
-  acl          = "public-read"
-  content_type = lookup(local.mime_types, regex("\\.[^.]+$", each.value), local.default_mime_type)
+  for_each = fileset(var.source_files, "**")
+  bucket   = aws_s3_bucket.app_bucket.id
+  key      = each.value
+  source   = "${var.source_files}/${each.value}"
+  etag     = filemd5("${var.source_files}/${each.value}")
+  acl      = "public-read"
+  content_type = (
+    length(regexall("\\.[^.]+$", each.value)) > 0 ?
+    lookup(local.mime_types, regex("\\.[^.]+$", each.value), local.default_mime_type) :
+    local.default_mime_type
+  )
 }
 
 resource "betteruptime_monitor" "this" {


### PR DESCRIPTION
This should handle the case where there is no `.` in the filename.