### PR TITLE
feat: public-read bucket policy + portfolio CI workflows (closes #14)

### DIFF
--- a/.github/LABELING.md
+++ b/.github/LABELING.md
@@ -1,0 +1,118 @@
+# 🏷️ Automatic PR Labeling System
+
+This repository uses an automatic labeling system that applies labels to pull requests based on branch naming conventions.
+
+## 🎯 How It Works
+
+When you create a PR, the system analyzes your branch name and automatically applies appropriate labels. This helps with:
+
+- **Organization**: Quickly identify the type of changes in a PR
+- **Release Management**: Automatic version bumping based on change types
+- **Workflow Automation**: Trigger different actions based on label types
+
+## 🌳 Branch Naming Conventions
+
+### User-Specific Patterns
+Perfect for your personal workflow:
+
+```
+jp/b/fix-login-bug          → 🐛 bug
+jp/f/add-dark-mode          → ✨ feature
+jp/d/update-readme          → 📚 docs
+jp/c/cleanup-old-code       → 🧹 chore
+jp/fix/authentication      → 🐛 bug
+jp/feat/new-dashboard       → ✨ feature
+jp/refactor/api-client      → ♻️ refactor
+jp/test/add-unit-tests      → 🧪 test
+jp/perf/optimize-queries    → ⚡ performance
+jp/security/fix-xss         → 🔒 security
+```
+
+### Standard Patterns
+Also supports conventional naming:
+
+```
+bug/fix-memory-leak         → 🐛 bug
+feature/user-profiles       → ✨ feature
+docs/api-documentation      → 📚 docs
+chore/update-dependencies   → 🧹 chore
+refactor/clean-components   → ♻️ refactor
+test/integration-tests      → 🧪 test
+perf/lazy-loading          → ⚡ performance
+security/auth-improvements  → 🔒 security
+hotfix/critical-bug        → 🚨 hotfix + 🐛 bug
+release/v2.0.0             → 🚀 release
+dependabot/npm/...         → 📦 dependencies
+```
+
+### Content-Based Detection
+Smart detection based on branch content:
+
+```
+ci-pipeline-fix            → 🔧 ci/cd
+config-updates             → ⚙️ config
+style-improvements         → 🎨 style
+api-endpoint-changes       → 🔌 api
+database-migration         → 🗄️ database
+```
+
+## 🏷️ Available Labels
+
+| Label | Color | Description |
+|-------|--------|-------------|
+| 🐛 bug | ![#dc2626](https://img.shields.io/badge/-dc2626-dc2626) | Something isn't working |
+| ✨ feature | ![#16a34a](https://img.shields.io/badge/-16a34a-16a34a) | New feature or enhancement |
+| 📚 docs | ![#2563eb](https://img.shields.io/badge/-2563eb-2563eb) | Documentation updates |
+| 🧹 chore | ![#6b7280](https://img.shields.io/badge/-6b7280-6b7280) | Maintenance tasks |
+| ♻️ refactor | ![#eab308](https://img.shields.io/badge/-eab308-eab308) | Code refactoring |
+| 🧪 test | ![#a855f7](https://img.shields.io/badge/-a855f7-a855f7) | Test-related changes |
+| ⚡ performance | ![#f59e0b](https://img.shields.io/badge/-f59e0b-f59e0b) | Performance improvements |
+| 🔒 security | ![#dc2626](https://img.shields.io/badge/-dc2626-dc2626) | Security-related changes |
+| 🚨 hotfix | ![#dc2626](https://img.shields.io/badge/-dc2626-dc2626) | Critical bug fix |
+| 🚀 release | ![#059669](https://img.shields.io/badge/-059669-059669) | Release preparation |
+| 📦 dependencies | ![#0369a1](https://img.shields.io/badge/-0369a1-0369a1) | Dependency updates |
+| 🔧 ci/cd | ![#7c3aed](https://img.shields.io/badge/-7c3aed-7c3aed) | CI/CD pipeline changes |
+| ⚙️ config | ![#4b5563](https://img.shields.io/badge/-4b5563-4b5563) | Configuration changes |
+| 🎨 style | ![#ec4899](https://img.shields.io/badge/-ec4899-ec4899) | UI/UX and styling |
+| 🔌 api | ![#059669](https://img.shields.io/badge/-059669-059669) | API-related changes |
+| 🗄️ database | ![#7c2d12](https://img.shields.io/badge/-7c2d12-7c2d12) | Database changes |
+
+### Version Labels (Required for Release)
+| Label | Color | Description |
+|-------|--------|-------------|
+| major | ![#d93f0b](https://img.shields.io/badge/-d93f0b-d93f0b) | Breaking changes (1.0.0 → 2.0.0) |
+| minor | ![#fbca04](https://img.shields.io/badge/-fbca04-fbca04) | New features (1.0.0 → 1.1.0) |
+| patch | ![#0e8a16](https://img.shields.io/badge/-0e8a16-0e8a16) | Bug fixes (1.0.0 → 1.0.1) |
+
+## 🚀 Release Automation
+
+The labeling system integrates with our release workflow:
+
+1. **Auto-labeling** applies type labels based on branch names
+2. **Version validation** ensures every PR has a version label (major/minor/patch)
+3. **Smart suggestions** recommend version labels based on detected change types
+4. **Automated releases** use labels to determine version bumps
+
+## 🔧 Manual Override
+
+You can always manually add, remove, or change labels on any PR. The automation is designed to be helpful, not restrictive.
+
+## 🎯 Best Practices
+
+1. **Use descriptive branch names** - they help with automatic labeling
+2. **Follow the naming conventions** - especially the `user/type/description` pattern
+3. **Add version labels** - required for releases (major/minor/patch)
+4. **Review auto-applied labels** - make sure they're accurate
+5. **Add additional labels** - if needed for better categorization
+
+## 🛠️ Setup
+
+The labeling system is automatically configured when you run the "Setup Repository Labels" workflow. It:
+
+- Creates all standard labels with proper colors
+- Updates existing labels to match the standard
+- Ensures consistency across the repository
+
+---
+
+*This system is designed to make your workflow smoother while maintaining consistency across the project. If you have suggestions for improvements, please create an issue or PR!*

--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -1,0 +1,219 @@
+name: 'Rate-Limited Slack Notification'
+description: 'Send Slack notifications with proper rate limiting and retry logic'
+author: 'porta.codes'
+
+inputs:
+  webhook_url:
+    description: 'Slack webhook URL'
+    required: true
+  status:
+    description: 'Job status (success, failure, cancelled)'
+    required: true
+  environment:
+    description: 'Environment name (development, staging, production, dns)'
+    required: false
+    default: 'unknown'
+  workflow_name:
+    description: 'Workflow name for context'
+    required: false
+    default: ${{ github.workflow }}
+  max_retries:
+    description: 'Maximum number of retry attempts'
+    required: false
+    default: '3'
+  base_delay:
+    description: 'Base delay in seconds for exponential backoff'
+    required: false
+    default: '1'
+
+outputs:
+  success:
+    description: 'Whether the notification was sent successfully'
+    value: ${{ steps.notify.outputs.success }}
+  attempts:
+    description: 'Number of attempts made'
+    value: ${{ steps.notify.outputs.attempts }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Send Slack notification with rate limiting
+      id: notify
+      shell: bash
+      run: |
+        #!/bin/bash
+        set -euo pipefail
+
+        # Input validation
+        WEBHOOK_URL="${{ inputs.webhook_url }}"
+        STATUS="${{ inputs.status }}"
+        ENVIRONMENT="${{ inputs.environment }}"
+        WORKFLOW_NAME="${{ inputs.workflow_name }}"
+        MAX_RETRIES="${{ inputs.max_retries }}"
+        BASE_DELAY="${{ inputs.base_delay }}"
+
+        if [[ -z "$WEBHOOK_URL" ]]; then
+          echo "::warning::SLACK_WEBHOOK_URL not provided, skipping notification"
+          echo "success=false" >> $GITHUB_OUTPUT
+          echo "attempts=0" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        # Determine status emoji and color
+        case "$STATUS" in
+          "success")
+            EMOJI="✅"
+            COLOR="#36a64f"
+            ;;
+          "failure")
+            EMOJI="❌"
+            COLOR="#ff0000"
+            ;;
+          "cancelled")
+            EMOJI="⚠️"
+            COLOR="#ffb02e"
+            ;;
+          *)
+            EMOJI="ℹ️"
+            COLOR="#439fe0"
+            ;;
+        esac
+
+        # Create message payload
+        REPO_NAME="${GITHUB_REPOSITORY##*/}"
+        COMMIT_MSG=$(git log -1 --pretty=format:'%s' || echo "Unknown commit")
+        COMMIT_SHA="${GITHUB_SHA:0:7}"
+        BRANCH_NAME="${GITHUB_REF_NAME}"
+        RUN_URL="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+        # Build Slack message
+        MESSAGE=$(cat <<EOF
+        {
+          "attachments": [
+            {
+              "color": "$COLOR",
+              "fields": [
+                {
+                  "title": "$EMOJI $WORKFLOW_NAME",
+                  "value": "Status: *$STATUS*\nEnvironment: *$ENVIRONMENT*\nRepository: *$REPO_NAME*\nBranch: *$BRANCH_NAME*\nCommit: *$COMMIT_SHA*\n\n$COMMIT_MSG",
+                  "short": false
+                }
+              ],
+              "actions": [
+                {
+                  "type": "button",
+                  "text": "View Run",
+                  "url": "$RUN_URL"
+                }
+              ],
+              "footer": "GitHub Actions",
+              "ts": $(date +%s)
+            }
+          ]
+        }
+        EOF
+        )
+
+        # Function to send notification with retry logic
+        send_notification() {
+          local attempt=1
+          local success=false
+
+          while [[ $attempt -le $MAX_RETRIES ]]; do
+            echo "Attempt $attempt/$MAX_RETRIES: Sending Slack notification..."
+
+            # Send request and capture response
+            RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+              -H "Content-Type: application/json" \
+              -d "$MESSAGE" \
+              "$WEBHOOK_URL")
+
+            # Extract HTTP status code
+            HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+            RESPONSE_BODY=$(echo "$RESPONSE" | head -n -1)
+
+            echo "HTTP Status: $HTTP_CODE"
+
+            case "$HTTP_CODE" in
+              "200")
+                echo "✅ Slack notification sent successfully"
+                success=true
+                break
+                ;;
+              "429")
+                echo "⚠️ Rate limited by Slack API"
+
+                # Try to extract Retry-After header from response
+                RETRY_AFTER=""
+                if command -v jq >/dev/null 2>&1 && [[ -n "$RESPONSE_BODY" ]]; then
+                  RETRY_AFTER=$(echo "$RESPONSE_BODY" | jq -r '.retry_after // empty' 2>/dev/null)
+                fi
+
+                if [[ -n "$RETRY_AFTER" && "$RETRY_AFTER" =~ ^[0-9]+$ ]]; then
+                  DELAY=$RETRY_AFTER
+                  echo "Using Retry-After header: ${DELAY}s"
+                else
+                  # Exponential backoff with jitter
+                  DELAY=$((BASE_DELAY * (2 ** (attempt - 1))))
+                  JITTER=$((RANDOM % 1000))  # 0-999ms
+                  DELAY_MS=$((DELAY * 1000 + JITTER))
+                  DELAY=$((DELAY_MS / 1000))
+                  echo "Using exponential backoff: ${DELAY}s"
+                fi
+
+                if [[ $attempt -lt $MAX_RETRIES ]]; then
+                  echo "Waiting ${DELAY}s before retry..."
+                  sleep "$DELAY"
+                fi
+                ;;
+              "400")
+                echo "❌ Bad request - check webhook URL and message format"
+                echo "Response: $RESPONSE_BODY"
+                break
+                ;;
+              "403")
+                echo "❌ Forbidden - check webhook URL permissions"
+                break
+                ;;
+              "404")
+                echo "❌ Webhook not found - check webhook URL"
+                break
+                ;;
+              "500"|"502"|"503"|"504")
+                echo "⚠️ Server error (${HTTP_CODE}) - retrying..."
+                if [[ $attempt -lt $MAX_RETRIES ]]; then
+                  DELAY=$((BASE_DELAY * (2 ** (attempt - 1))))
+                  echo "Waiting ${DELAY}s before retry..."
+                  sleep "$DELAY"
+                fi
+                ;;
+              *)
+                echo "❌ Unexpected HTTP status: $HTTP_CODE"
+                echo "Response: $RESPONSE_BODY"
+                break
+                ;;
+            esac
+
+            ((attempt++))
+          done
+
+          # Set outputs
+          echo "success=$success" >> $GITHUB_OUTPUT
+          echo "attempts=$((attempt-1))" >> $GITHUB_OUTPUT
+
+          if [[ "$success" != "true" ]]; then
+            echo "::error::Failed to send Slack notification after $((attempt-1)) attempts"
+            # Don't fail the job, just log the error
+            return 0
+          fi
+        }
+
+        # Add small random delay to prevent thundering herd
+        INITIAL_DELAY=$((RANDOM % 3))
+        if [[ $INITIAL_DELAY -gt 0 ]]; then
+          echo "Adding ${INITIAL_DELAY}s initial delay to prevent concurrent requests..."
+          sleep "$INITIAL_DELAY"
+        fi
+
+        # Send the notification
+        send_notification

--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -130,28 +130,59 @@ runs:
             }]
           }')
 
-        # Function to send notification with retry logic
+        # Function to send notification with retry logic.
         send_notification() {
           local attempt=1
+          local attempts_made=0    # tracks real attempt count for the output
           local success=false
 
+          # Tempfile lifecycle: create once outside the loop, allocate fresh
+          # paths per iteration, and trap-clean on any exit (including
+          # `set -e` triggered by curl). This prevents leaks if the script
+          # is killed mid-iteration.
+          local HEADERS_FILE=""
+          local BODY_FILE=""
+          # shellcheck disable=SC2064
+          trap 'rm -f "$HEADERS_FILE" "$BODY_FILE"' RETURN INT TERM
+
           while [[ $attempt -le $MAX_RETRIES ]]; do
+            attempts_made=$attempt
             echo "Attempt $attempt/$MAX_RETRIES: Sending Slack notification..."
+
+            HEADERS_FILE="$(mktemp)"
+            BODY_FILE="$(mktemp)"
 
             # Capture response headers and body separately. Slack returns
             # rate-limit info in the Retry-After HTTP header (per Slack docs),
             # not the response body — so we need -D to dump headers to a file.
-            HEADERS_FILE="$(mktemp)"
-            BODY_FILE="$(mktemp)"
+            #
+            # Capture curl's exit code without letting `set -e` abort the loop
+            # on transient failures (DNS, TLS, TCP timeout, etc.). --max-time
+            # bounds the request so we can't hang the runner.
+            HTTP_CODE=""
+            CURL_EXIT=0
             HTTP_CODE="$(curl -sS \
+              --connect-timeout 10 \
+              --max-time 30 \
               -D "$HEADERS_FILE" \
               -o "$BODY_FILE" \
               -w "%{http_code}" \
               -X POST \
               -H "Content-Type: application/json" \
               -d "$MESSAGE" \
-              "$WEBHOOK_URL")"
-            RESPONSE_BODY="$(cat "$BODY_FILE")"
+              "$WEBHOOK_URL")" || CURL_EXIT=$?
+            RESPONSE_BODY="$(cat "$BODY_FILE" 2>/dev/null || true)"
+
+            if [[ $CURL_EXIT -ne 0 ]]; then
+              echo "⚠️ curl failed with exit $CURL_EXIT (network/timeout); will retry if attempts remain"
+              if [[ $attempt -lt $MAX_RETRIES ]]; then
+                DELAY=$((BASE_DELAY * (2 ** (attempt - 1))))
+                echo "Waiting ${DELAY}s before retry..."
+                sleep "$DELAY"
+              fi
+              ((attempt++))
+              continue
+            fi
 
             echo "HTTP Status: $HTTP_CODE"
 
@@ -159,15 +190,14 @@ runs:
               "200")
                 echo "✅ Slack notification sent successfully"
                 success=true
-                rm -f "$HEADERS_FILE" "$BODY_FILE"
                 break
                 ;;
               "429")
                 echo "⚠️ Rate limited by Slack API"
 
                 # Per Slack docs, 429 carries a Retry-After header (in seconds).
-                # Header name is case-insensitive; tolower() handles both
-                # "Retry-After" and "retry-after". Strip any trailing CR.
+                # IGNORECASE handles both "Retry-After" and "retry-after". Strip
+                # any trailing CR from the HTTP/1.1 line ending.
                 RETRY_AFTER="$(awk 'BEGIN{IGNORECASE=1} /^retry-after:/ {print $2}' "$HEADERS_FILE" | tr -d '\r' | head -n1)"
 
                 if [[ -n "$RETRY_AFTER" && "$RETRY_AFTER" =~ ^[0-9]+$ ]]; then
@@ -182,7 +212,6 @@ runs:
                   echo "Using exponential backoff: ${DELAY}s"
                 fi
 
-                rm -f "$HEADERS_FILE" "$BODY_FILE"
                 if [[ $attempt -lt $MAX_RETRIES ]]; then
                   echo "Waiting ${DELAY}s before retry..."
                   sleep "$DELAY"
@@ -191,22 +220,18 @@ runs:
               "400")
                 echo "❌ Bad request - check webhook URL and message format"
                 echo "Response: $RESPONSE_BODY"
-                rm -f "$HEADERS_FILE" "$BODY_FILE"
                 break
                 ;;
               "403")
                 echo "❌ Forbidden - check webhook URL permissions"
-                rm -f "$HEADERS_FILE" "$BODY_FILE"
                 break
                 ;;
               "404")
                 echo "❌ Webhook not found - check webhook URL"
-                rm -f "$HEADERS_FILE" "$BODY_FILE"
                 break
                 ;;
               "500"|"502"|"503"|"504")
                 echo "⚠️ Server error (${HTTP_CODE}) - retrying..."
-                rm -f "$HEADERS_FILE" "$BODY_FILE"
                 if [[ $attempt -lt $MAX_RETRIES ]]; then
                   DELAY=$((BASE_DELAY * (2 ** (attempt - 1))))
                   echo "Waiting ${DELAY}s before retry..."
@@ -216,7 +241,6 @@ runs:
               *)
                 echo "❌ Unexpected HTTP status: $HTTP_CODE"
                 echo "Response: $RESPONSE_BODY"
-                rm -f "$HEADERS_FILE" "$BODY_FILE"
                 break
                 ;;
             esac
@@ -224,9 +248,11 @@ runs:
             ((attempt++))
           done
 
-          # Set outputs
+          # Set outputs — use the actual count (attempts_made), which is
+          # written before any break/continue so success-on-first-try reports
+          # attempts=1 (not 0).
           echo "success=$success" >> $GITHUB_OUTPUT
-          echo "attempts=$((attempt-1))" >> $GITHUB_OUTPUT
+          echo "attempts=$attempts_made" >> $GITHUB_OUTPUT
 
           if [[ "$success" != "true" ]]; then
             echo "::error::Failed to send Slack notification after $((attempt-1)) attempts"

--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -86,33 +86,49 @@ runs:
         BRANCH_NAME="${GITHUB_REF_NAME}"
         RUN_URL="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
-        # Build Slack message
-        MESSAGE=$(cat <<EOF
-        {
-          "attachments": [
-            {
-              "color": "$COLOR",
-              "fields": [
-                {
-                  "title": "$EMOJI $WORKFLOW_NAME",
-                  "value": "Status: *$STATUS*\nEnvironment: *$ENVIRONMENT*\nRepository: *$REPO_NAME*\nBranch: *$BRANCH_NAME*\nCommit: *$COMMIT_SHA*\n\n$COMMIT_MSG",
-                  "short": false
-                }
-              ],
-              "actions": [
-                {
-                  "type": "button",
-                  "text": "View Run",
-                  "url": "$RUN_URL"
-                }
-              ],
-              "footer": "GitHub Actions",
-              "ts": $(date +%s)
-            }
-          ]
-        }
-        EOF
-        )
+        # Build Slack message via `jq -n --arg ...` so commit messages, branch
+        # names, or workflow names containing quotes/newlines/backslashes
+        # cannot break the JSON payload or inject unintended structure.
+        if ! command -v jq >/dev/null 2>&1; then
+          echo "::error::jq is required to build the Slack payload safely. Install it on the runner."
+          echo "success=false" >> $GITHUB_OUTPUT
+          echo "attempts=0" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        MESSAGE=$(jq -n \
+          --arg color       "$COLOR" \
+          --arg title       "$EMOJI $WORKFLOW_NAME" \
+          --arg status      "$STATUS" \
+          --arg environment "$ENVIRONMENT" \
+          --arg repo        "$REPO_NAME" \
+          --arg branch      "$BRANCH_NAME" \
+          --arg commit_sha  "$COMMIT_SHA" \
+          --arg commit_msg  "$COMMIT_MSG" \
+          --arg run_url     "$RUN_URL" \
+          --argjson ts      "$(date +%s)" '
+          {
+            attachments: [{
+              color: $color,
+              fields: [{
+                title: $title,
+                value: ("Status: *\($status)*\n" +
+                        "Environment: *\($environment)*\n" +
+                        "Repository: *\($repo)*\n" +
+                        "Branch: *\($branch)*\n" +
+                        "Commit: *\($commit_sha)*\n\n" +
+                        $commit_msg),
+                short: false
+              }],
+              actions: [{
+                type: "button",
+                text: "View Run",
+                url: $run_url
+              }],
+              footer: "GitHub Actions",
+              ts: $ts
+            }]
+          }')
 
         # Function to send notification with retry logic
         send_notification() {
@@ -122,15 +138,20 @@ runs:
           while [[ $attempt -le $MAX_RETRIES ]]; do
             echo "Attempt $attempt/$MAX_RETRIES: Sending Slack notification..."
 
-            # Send request and capture response
-            RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+            # Capture response headers and body separately. Slack returns
+            # rate-limit info in the Retry-After HTTP header (per Slack docs),
+            # not the response body — so we need -D to dump headers to a file.
+            HEADERS_FILE="$(mktemp)"
+            BODY_FILE="$(mktemp)"
+            HTTP_CODE="$(curl -sS \
+              -D "$HEADERS_FILE" \
+              -o "$BODY_FILE" \
+              -w "%{http_code}" \
+              -X POST \
               -H "Content-Type: application/json" \
               -d "$MESSAGE" \
-              "$WEBHOOK_URL")
-
-            # Extract HTTP status code
-            HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-            RESPONSE_BODY=$(echo "$RESPONSE" | head -n -1)
+              "$WEBHOOK_URL")"
+            RESPONSE_BODY="$(cat "$BODY_FILE")"
 
             echo "HTTP Status: $HTTP_CODE"
 
@@ -138,16 +159,16 @@ runs:
               "200")
                 echo "✅ Slack notification sent successfully"
                 success=true
+                rm -f "$HEADERS_FILE" "$BODY_FILE"
                 break
                 ;;
               "429")
                 echo "⚠️ Rate limited by Slack API"
 
-                # Try to extract Retry-After header from response
-                RETRY_AFTER=""
-                if command -v jq >/dev/null 2>&1 && [[ -n "$RESPONSE_BODY" ]]; then
-                  RETRY_AFTER=$(echo "$RESPONSE_BODY" | jq -r '.retry_after // empty' 2>/dev/null)
-                fi
+                # Per Slack docs, 429 carries a Retry-After header (in seconds).
+                # Header name is case-insensitive; tolower() handles both
+                # "Retry-After" and "retry-after". Strip any trailing CR.
+                RETRY_AFTER="$(awk 'BEGIN{IGNORECASE=1} /^retry-after:/ {print $2}' "$HEADERS_FILE" | tr -d '\r' | head -n1)"
 
                 if [[ -n "$RETRY_AFTER" && "$RETRY_AFTER" =~ ^[0-9]+$ ]]; then
                   DELAY=$RETRY_AFTER
@@ -161,6 +182,7 @@ runs:
                   echo "Using exponential backoff: ${DELAY}s"
                 fi
 
+                rm -f "$HEADERS_FILE" "$BODY_FILE"
                 if [[ $attempt -lt $MAX_RETRIES ]]; then
                   echo "Waiting ${DELAY}s before retry..."
                   sleep "$DELAY"
@@ -169,18 +191,22 @@ runs:
               "400")
                 echo "❌ Bad request - check webhook URL and message format"
                 echo "Response: $RESPONSE_BODY"
+                rm -f "$HEADERS_FILE" "$BODY_FILE"
                 break
                 ;;
               "403")
                 echo "❌ Forbidden - check webhook URL permissions"
+                rm -f "$HEADERS_FILE" "$BODY_FILE"
                 break
                 ;;
               "404")
                 echo "❌ Webhook not found - check webhook URL"
+                rm -f "$HEADERS_FILE" "$BODY_FILE"
                 break
                 ;;
               "500"|"502"|"503"|"504")
                 echo "⚠️ Server error (${HTTP_CODE}) - retrying..."
+                rm -f "$HEADERS_FILE" "$BODY_FILE"
                 if [[ $attempt -lt $MAX_RETRIES ]]; then
                   DELAY=$((BASE_DELAY * (2 ** (attempt - 1))))
                   echo "Waiting ${DELAY}s before retry..."
@@ -190,6 +216,7 @@ runs:
               *)
                 echo "❌ Unexpected HTTP status: $HTTP_CODE"
                 echo "Response: $RESPONSE_BODY"
+                rm -f "$HEADERS_FILE" "$BODY_FILE"
                 break
                 ;;
             esac

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -1,0 +1,133 @@
+name: 🏷️✨ Auto-Label PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+env:
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+jobs:
+  auto-label:
+    name: Auto-Label Based on Branch Name
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: 📥 Checkout repository
+      uses: actions/checkout@v4
+
+    - name: 🏷️ Apply labels based on branch name
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const branchName = context.payload.pull_request.head.ref;
+          const prNumber = context.payload.pull_request.number;
+
+          console.log(`Processing branch: ${branchName}`);
+
+          // Define label mappings based on branch patterns
+          const labelMappings = [
+            // User-specific patterns (jp/type/description)
+            { pattern: /^[^/]+\/b\//, labels: ['🐛 bug'] },
+            { pattern: /^[^/]+\/f\//, labels: ['✨ feature'] },
+            { pattern: /^[^/]+\/d\//, labels: ['📚 docs'] },
+            { pattern: /^[^/]+\/c\//, labels: ['🧹 chore'] },
+            { pattern: /^[^/]+\/fix\//, labels: ['🐛 bug'] },
+            { pattern: /^[^/]+\/feat\//, labels: ['✨ feature'] },
+            { pattern: /^[^/]+\/doc\//, labels: ['📚 docs'] },
+            { pattern: /^[^/]+\/chore\//, labels: ['🧹 chore'] },
+            { pattern: /^[^/]+\/refactor\//, labels: ['♻️ refactor'] },
+            { pattern: /^[^/]+\/test\//, labels: ['🧪 test'] },
+            { pattern: /^[^/]+\/perf\//, labels: ['⚡ performance'] },
+            { pattern: /^[^/]+\/security\//, labels: ['🔒 security'] },
+
+            // Standard patterns (without user prefix)
+            { pattern: /^bug\//, labels: ['🐛 bug'] },
+            { pattern: /^bugfix\//, labels: ['🐛 bug'] },
+            { pattern: /^fix\//, labels: ['🐛 bug'] },
+            { pattern: /^feature\//, labels: ['✨ feature'] },
+            { pattern: /^feat\//, labels: ['✨ feature'] },
+            { pattern: /^docs\//, labels: ['📚 docs'] },
+            { pattern: /^doc\//, labels: ['📚 docs'] },
+            { pattern: /^chore\//, labels: ['🧹 chore'] },
+            { pattern: /^refactor\//, labels: ['♻️ refactor'] },
+            { pattern: /^test\//, labels: ['🧪 test'] },
+            { pattern: /^tests\//, labels: ['🧪 test'] },
+            { pattern: /^perf\//, labels: ['⚡ performance'] },
+            { pattern: /^performance\//, labels: ['⚡ performance'] },
+            { pattern: /^security\//, labels: ['🔒 security'] },
+            { pattern: /^sec\//, labels: ['🔒 security'] },
+            { pattern: /^hotfix\//, labels: ['🚨 hotfix', '🐛 bug'] },
+            { pattern: /^release\//, labels: ['🚀 release'] },
+            { pattern: /^dependabot\//, labels: ['📦 dependencies'] },
+            { pattern: /^deps\//, labels: ['📦 dependencies'] },
+            { pattern: /^dependencies\//, labels: ['📦 dependencies'] },
+
+            // Content-based patterns
+            { pattern: /ci|pipeline|workflow|github/, labels: ['🔧 ci/cd'] },
+            { pattern: /config|configuration|settings/, labels: ['⚙️ config'] },
+            { pattern: /style|css|ui|ux/, labels: ['🎨 style'] },
+            { pattern: /api|endpoint|service/, labels: ['🔌 api'] },
+            { pattern: /database|db|migration/, labels: ['🗄️ database'] },
+          ];
+
+          // Find matching labels
+          const labelsToApply = new Set();
+
+          for (const mapping of labelMappings) {
+            if (mapping.pattern.test(branchName.toLowerCase())) {
+              mapping.labels.forEach(label => labelsToApply.add(label));
+            }
+          }
+
+          // Convert to array
+          const finalLabels = Array.from(labelsToApply);
+
+          if (finalLabels.length > 0) {
+            console.log(`Applying labels: ${finalLabels.join(', ')}`);
+
+            // Get current PR labels
+            const { data: currentPR } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            const currentLabels = currentPR.labels.map(label => label.name);
+
+            // Only add labels that aren't already present
+            const newLabels = finalLabels.filter(label => !currentLabels.includes(label));
+
+            if (newLabels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: newLabels
+              });
+
+              console.log(`✅ Added labels: ${newLabels.join(', ')}`);
+            } else {
+              console.log(`ℹ️ All relevant labels already applied`);
+            }
+          } else {
+            console.log(`ℹ️ No matching labels found for branch: ${branchName}`);
+          }
+
+    - name: 📢 Notify Slack
+      uses: ./.github/actions/slack-notify
+      with:
+        webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
+        status: ${{ job.status }}
+        environment: 'pr-automation'
+        workflow_name: ${{ github.workflow }}
+      if: always()

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -1,20 +1,26 @@
 name: 🏷️✨ Auto-Label PRs
 
+# Uses pull_request_target instead of pull_request so the workflow runs in
+# the context of the BASE branch, not the PR branch — PR-modified workflow
+# code or local composite actions cannot run with this token. Safe for
+# label-only metadata work; do NOT add code-build steps here without
+# carefully reviewing the implications.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege permissions: issues:write covers labels (PRs are issues
+# under the hood for the labels API). Slack notifications are intentionally
+# not part of this metadata workflow — keep PR-controlled code paths away
+# from the webhook secret.
 permissions:
   contents: read
   issues: write
-  pull-requests: write
-
-env:
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  pull-requests: read
 
 jobs:
   auto-label:
@@ -22,11 +28,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: 📥 Checkout repository
-      uses: actions/checkout@v4
-
+    # No actions/checkout — this workflow only needs PR metadata via the
+    # GitHub API. Skipping checkout means PR-controlled code never lands
+    # on this runner.
     - name: 🏷️ Apply labels based on branch name
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const branchName = context.payload.pull_request.head.ref;
@@ -122,12 +128,3 @@ jobs:
           } else {
             console.log(`ℹ️ No matching labels found for branch: ${branchName}`);
           }
-
-    - name: 📢 Notify Slack
-      uses: ./.github/actions/slack-notify
-      with:
-        webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
-        status: ${{ job.status }}
-        environment: 'pr-automation'
-        workflow_name: ${{ github.workflow }}
-      if: always()

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,109 @@
+name: 🏷️ PR Label Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+env:
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+jobs:
+  validate-labels:
+    name: Validate Version Labels
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: 📥 Checkout repository
+      uses: actions/checkout@v4
+
+    - name: 🏷️ Check for required version labels
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const { data: pullRequest } = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number
+          });
+
+          const labels = pullRequest.labels.map(label => label.name);
+          const versionLabels = ['major', 'minor', 'patch'];
+          const hasVersionLabel = versionLabels.some(label => labels.includes(label));
+
+          if (!hasVersionLabel) {
+            const branchName = context.payload.pull_request.head.ref;
+            const suggestedLabel = branchName.includes('/f/') || branchName.includes('/feat') || branchName.includes('feature') ? 'minor' : 'patch';
+
+            const comment = `## 🏷️ Version Label Required
+
+            This PR needs a version label to determine the type of release:
+
+            - \`major\` - Breaking changes (e.g., 1.0.0 → 2.0.0)
+            - \`minor\` - New features (e.g., 1.0.0 → 1.1.0)
+            - \`patch\` - Bug fixes (e.g., 1.0.0 → 1.0.1)
+
+            **💡 Suggestion:** Based on your branch name \`${branchName}\`, this looks like a **${suggestedLabel}** release.
+
+            Please add one of these labels to this PR.`;
+
+            // Check if comment already exists
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            const existingComment = comments.find(comment =>
+              comment.body.includes('Version Label Required')
+            );
+
+            if (!existingComment) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: comment
+              });
+            }
+
+            core.setFailed('PR is missing a version label (major, minor, or patch)');
+          } else {
+            // Remove the comment if it exists and labels are now present
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            const existingComment = comments.find(comment =>
+              comment.body.includes('Version Label Required')
+            );
+
+            if (existingComment) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id
+              });
+            }
+
+            console.log(`✅ PR has version label: ${labels.filter(l => versionLabels.includes(l)).join(', ')}`);
+          }
+
+    - name: 📢 Notify Slack
+      uses: ./.github/actions/slack-notify
+      with:
+        webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
+        status: ${{ job.status }}
+        environment: 'pr-validation'
+        workflow_name: ${{ github.workflow }}
+      if: always()

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,20 +1,26 @@
 name: 🏷️ PR Label Validation
 
+# Uses pull_request_target instead of pull_request so the workflow runs in
+# the context of the BASE branch, not the PR branch — PR-modified workflow
+# code or local composite actions cannot run with this token. Safe for
+# label-only metadata work; do NOT add code-build steps here without
+# carefully reviewing the implications.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, labeled, unlabeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege permissions: issues:write for labels and PR comments
+# (PRs are issues under the hood for those APIs). Slack notifications are
+# intentionally not part of this metadata workflow — keep PR-controlled
+# code paths away from the webhook secret.
 permissions:
   contents: read
   issues: write
-  pull-requests: write
-
-env:
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  pull-requests: read
 
 jobs:
   validate-labels:
@@ -22,11 +28,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: 📥 Checkout repository
-      uses: actions/checkout@v4
-
+    # No actions/checkout — this workflow only needs PR metadata via the
+    # GitHub API. Skipping checkout means PR-controlled code never lands
+    # on this runner.
     - name: 🏷️ Check for required version labels
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const { data: pullRequest } = await github.rest.pulls.get({
@@ -104,12 +110,3 @@ jobs:
 
             console.log(`✅ PR has version label: ${labels.filter(l => versionLabels.includes(l)).join(', ')}`);
           }
-
-    - name: 📢 Notify Slack
-      uses: ./.github/actions/slack-notify
-      with:
-        webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
-        status: ${{ job.status }}
-        environment: 'pr-validation'
-        workflow_name: ${{ github.workflow }}
-      if: always()

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -43,17 +43,23 @@ jobs:
             const branchName = context.payload.pull_request.head.ref;
             const suggestedLabel = branchName.includes('/f/') || branchName.includes('/feat') || branchName.includes('feature') ? 'minor' : 'patch';
 
-            const comment = `## 🏷️ Version Label Required
-
-            This PR needs a version label to determine the type of release:
-
-            - \`major\` - Breaking changes (e.g., 1.0.0 → 2.0.0)
-            - \`minor\` - New features (e.g., 1.0.0 → 1.1.0)
-            - \`patch\` - Bug fixes (e.g., 1.0.0 → 1.0.1)
-
-            **💡 Suggestion:** Based on your branch name \`${branchName}\`, this looks like a **${suggestedLabel}** release.
-
-            Please add one of these labels to this PR.`;
+            // Build the markdown comment without leading-indent on each
+            // line — the previous template literal carried the script's
+            // indentation through to the rendered comment, which Markdown
+            // would interpret as code blocks.
+            const comment = [
+              '## 🏷️ Version Label Required',
+              '',
+              'This PR needs a version label to determine the type of release:',
+              '',
+              '- `major` - Breaking changes (e.g., 1.0.0 → 2.0.0)',
+              '- `minor` - New features (e.g., 1.0.0 → 1.1.0)',
+              '- `patch` - Bug fixes (e.g., 1.0.0 → 1.0.1)',
+              '',
+              `**💡 Suggestion:** Based on your branch name \`${branchName}\`, this looks like a **${suggestedLabel}** release.`,
+              '',
+              'Please add one of these labels to this PR.',
+            ].join('\n');
 
             // Check if comment already exists
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/setup-labels.yml
+++ b/.github/workflows/setup-labels.yml
@@ -3,7 +3,11 @@ name: 🏷️ Setup Repository Labels
 on:
   workflow_dispatch:
   push:
-    branches: [ master ]
+    # Run on either default-branch convention. Different repos in this
+    # portfolio use master (terraform-aws-s3-static-site) and main
+    # (jonathanportarealtor.com etc.) — same workflow file works in both
+    # without needing per-repo edits.
+    branches: [master, main]
     paths:
       - '.github/workflows/setup-labels.yml'
 
@@ -15,7 +19,7 @@ jobs:
   setup-labels:
     name: Create Standard Labels
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
 
     steps:
     - name: 🏷️ Create or update repository labels

--- a/.github/workflows/setup-labels.yml
+++ b/.github/workflows/setup-labels.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: 🏷️ Create or update repository labels
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const labels = [

--- a/.github/workflows/setup-labels.yml
+++ b/.github/workflows/setup-labels.yml
@@ -1,0 +1,86 @@
+name: 🏷️ Setup Repository Labels
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+    paths:
+      - '.github/workflows/setup-labels.yml'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  setup-labels:
+    name: Create Standard Labels
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+    - name: 🏷️ Create or update repository labels
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const labels = [
+            // Standard labels
+            { name: '🐛 bug', color: 'dc2626', description: 'Something isn\'t working' },
+            { name: '✨ feature', color: '16a34a', description: 'New feature or enhancement' },
+            { name: '📚 docs', color: '2563eb', description: 'Documentation updates' },
+            { name: '🧹 chore', color: '6b7280', description: 'Maintenance tasks' },
+            { name: '♻️ refactor', color: 'eab308', description: 'Code refactoring' },
+            { name: '🧪 test', color: 'a855f7', description: 'Test-related changes' },
+            { name: '⚡ performance', color: 'f59e0b', description: 'Performance improvements' },
+            { name: '🔒 security', color: 'dc2626', description: 'Security-related changes' },
+            { name: '🚨 hotfix', color: 'dc2626', description: 'Critical bug fix' },
+            { name: '🚀 release', color: '059669', description: 'Release preparation' },
+            { name: '📦 dependencies', color: '0369a1', description: 'Dependency updates' },
+            { name: '🔧 ci/cd', color: '7c3aed', description: 'CI/CD pipeline changes' },
+            { name: '⚙️ config', color: '4b5563', description: 'Configuration changes' },
+            { name: '🎨 style', color: 'ec4899', description: 'UI/UX and styling' },
+            { name: '🔌 api', color: '059669', description: 'API-related changes' },
+            { name: '🗄️ database', color: '7c2d12', description: 'Database changes' },
+            // Deployment labels
+            { name: 'Development Deployment', color: '0d2002', description: 'Deployment to the Development environment' },
+            { name: 'Staging Deployment', color: '0d2002', description: 'Deployment to the Staging environment' },
+            { name: 'Production Deployment', color: '0d2002', description: 'Deployment to the Production environment' },
+            { name: 'DNS Deployment', color: '0d2002', description: 'Deployment of DNS and CDN rules to the Production Environment' },
+            // Version labels for releases
+            { name: 'major', color: 'd93f0b', description: 'Major version bump (breaking changes)' },
+            { name: 'minor', color: 'fbca04', description: 'Minor version bump (new features)' },
+            { name: 'patch', color: '0e8a16', description: 'Patch version bump (bug fixes)' },
+          ];
+
+          for (const label of labels) {
+            try {
+              // Try to update the label first
+              await github.rest.issues.updateLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label.name,
+                color: label.color,
+                description: label.description
+              });
+              console.log(`✅ Updated label: ${label.name}`);
+            } catch (error) {
+              if (error.status === 404) {
+                // Label doesn't exist, create it
+                try {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label.name,
+                    color: label.color,
+                    description: label.description
+                  });
+                  console.log(`✅ Created label: ${label.name}`);
+                } catch (createError) {
+                  console.error(`❌ Failed to create label ${label.name}:`, createError.message);
+                }
+              } else {
+                console.error(`❌ Failed to update label ${label.name}:`, error.message);
+              }
+            }
+          }
+
+          console.log('🎉 Label setup complete!');

--- a/.github/workflows/terraform-pr.yaml
+++ b/.github/workflows/terraform-pr.yaml
@@ -39,9 +39,12 @@ jobs:
     name: Check for pull request type label
     runs-on: ubuntu-latest
     steps:
+      # Label vocabulary aligned with .github/workflows/pr-auto-label.yml
+      # (the auto-labeler applies emoji-prefixed labels by branch convention).
+      # Any one of these from the auto-labeler set satisfies this gate.
       - uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          one_of: bug,enhancement,documentation,security
+          one_of: "🐛 bug,✨ feature,📚 docs,🔒 security,🔧 ci/cd,🧹 chore,♻️ refactor,🧪 test,⚡ performance,📦 dependencies,🚀 release,🚨 hotfix"
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
   docs:

--- a/.github/workflows/terraform-pr.yaml
+++ b/.github/workflows/terraform-pr.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Validate Terraform formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v2
 
       - name: Terraform Validate
@@ -53,7 +53,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 

--- a/.github/workflows/terraform-pr.yaml
+++ b/.github/workflows/terraform-pr.yaml
@@ -40,11 +40,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Label vocabulary aligned with .github/workflows/pr-auto-label.yml
-      # (the auto-labeler applies emoji-prefixed labels by branch convention).
-      # Any one of these from the auto-labeler set satisfies this gate.
+      # (the auto-labeler applies emoji-prefixed labels by branch convention
+      # AND content-based heuristics, so PRs may legitimately have multiple
+      # type labels — e.g., a feature touching CI gets ✨ feature + 🔧 ci/cd).
+      # Use any_of so multiple matches don't fail the gate; one_of would
+      # require *exactly* one, which conflicts with the auto-labeler's design.
       - uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          one_of: "🐛 bug,✨ feature,📚 docs,🔒 security,🔧 ci/cd,🧹 chore,♻️ refactor,🧪 test,⚡ performance,📦 dependencies,🚀 release,🚨 hotfix"
+          any_of: "🐛 bug,✨ feature,📚 docs,🔒 security,🔧 ci/cd,🧹 chore,♻️ refactor,🧪 test,⚡ performance,📦 dependencies,🚀 release,🚨 hotfix,⚙️ config,🎨 style,🔌 api,🗄️ database"
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
   docs:

--- a/.github/workflows/terraform-publish.yaml
+++ b/.github/workflows/terraform-publish.yaml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,44 @@
 
 Very simple Terraform module for deploying a static site into an S3 bucket.
 
+## Public access
+
+This module **intentionally creates a public S3 website bucket**. Anonymous `s3:GetObject` is granted via:
+
+- A bucket policy with `Principal: "*"` (the modern, post-2023 AWS approach)
+- A bucket-level `public-read` ACL (legacy, retained for backwards compatibility)
+- Per-object `public-read` ACLs on every uploaded file (legacy, retained)
+
+If you don't want a publicly readable bucket, this module is the wrong tool — it's designed specifically for static website hosting where every object must be readable by anonymous clients.
+
+### Account-level / organization-level Block Public Access
+
+This module sets *bucket-level* `public_access_block` flags to `false`. **Account-level or organization-level S3 Block Public Access settings can still override that** and prevent the public-read bucket policy from being applied or taking effect, even after `terraform apply` reports success. If anonymous requests return `403` against an apparently-applied bucket, check:
+
+```bash
+# Account level (replace with your account id)
+aws s3control get-public-access-block --account-id 123456789012
+
+# Organization-level: your AWS Organizations admin will know.
+```
+
+If `BlockPublicPolicy` or `RestrictPublicBuckets` is `true` at account/org level, this module won't be able to make the bucket public until those flags are turned off.
+
+### This module owns the bucket policy
+
+S3 buckets have a single bucket-policy document. This module's `aws_s3_bucket_policy.app_bucket_public_read` resource will be the source of truth for that document — **do not attach a separate manual bucket policy** to buckets managed by this module, or your changes will be overwritten on the next `terraform apply`. If you need additional statements (e.g., a `DenyInsecureTransport` block), submit a PR or maintain a fork.
+
+### v2 roadmap (planned)
+
+Modern AWS guidance is to disable ACLs entirely (`object_ownership = "BucketOwnerEnforced"`) and rely on bucket policies as the sole access-control mechanism. A future v2 of this module will:
+
+- Switch ownership to `BucketOwnerEnforced`
+- Remove the `aws_s3_bucket_acl` resource
+- Remove `acl = "public-read"` from `aws_s3_object` resources
+- Rely entirely on `aws_s3_bucket_policy` for public access
+
+This is a breaking change requiring a Terraform state migration, which is why it's deferred to a major version bump.
+
 ## Module Documentation
 
 <!-- BEGIN_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ No modules.
 | [aws_s3_bucket.app_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_acl.app_bucket_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_ownership_controls.app_bucket_acl_ownership](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_policy.app_bucket_public_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.app_bucket_public_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_versioning.app_bucket_versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_s3_bucket_website_configuration.app_bucket_website](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_website_configuration) | resource |

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,37 @@ resource "aws_s3_bucket_acl" "app_bucket_acl" {
   acl    = "public-read"
 }
 
+# Public-read bucket policy. The ACL approach above (acl = "public-read") was
+# the canonical pattern when this module was first written, but AWS has been
+# progressively deprecating public-read ACLs since April 2023. New buckets
+# created today often have ACL-based public access silently fail at the
+# request level — the ACL applies but anonymous GetObject requests still
+# return 403, which surfaces as Cloudflare error 522 ("connection to origin")
+# when the bucket is fronted by Cloudflare with SSL set to flexible.
+#
+# Adding an explicit aws_s3_bucket_policy is the modern, reliable equivalent.
+# Bucket policy + ACL coexist fine; the policy is what actually grants
+# public read in the post-2023 AWS world. depends_on the public-access-block
+# so the policy isn't rejected by a "block public policy" setting that races
+# with creation.
+resource "aws_s3_bucket_policy" "app_bucket_public_read" {
+  depends_on = [
+    aws_s3_bucket_public_access_block.app_bucket_public_access,
+  ]
+
+  bucket = aws_s3_bucket.app_bucket.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "PublicReadGetObject"
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = "s3:GetObject"
+      Resource  = "${aws_s3_bucket.app_bucket.arn}/*"
+    }]
+  })
+}
+
 resource "aws_s3_bucket_versioning" "app_bucket_versioning" {
   bucket = aws_s3_bucket.app_bucket.id
   versioning_configuration {

--- a/main.tf
+++ b/main.tf
@@ -38,8 +38,8 @@ resource "aws_s3_bucket_acl" "app_bucket_acl" {
 # progressively deprecating public-read ACLs since April 2023. New buckets
 # created today often have ACL-based public access silently fail at the
 # request level — the ACL applies but anonymous GetObject requests still
-# return 403, which surfaces as Cloudflare error 522 ("connection to origin")
-# when the bucket is fronted by Cloudflare with SSL set to flexible.
+# return 403. When this bucket is fronted by a CDN, that underlying S3 403
+# can surface as confusing edge/origin behavior during rollout.
 #
 # Adding an explicit aws_s3_bucket_policy is the modern, reliable equivalent.
 # Bucket policy + ACL coexist fine; the policy is what actually grants


### PR DESCRIPTION
## Summary

Two related changes preparing the module for a clean v1.1.0 release.

### 1. Public-read bucket policy

AWS has been progressively deprecating public-read ACLs since April 2023. New buckets created today often have ACL-based public access silently fail at the request level — the bucket ACL applies but anonymous `GetObject` requests still return `403`.

Adding an explicit `aws_s3_bucket_policy` granting `s3:GetObject` to `Principal: "*"` is the modern, reliable equivalent. Policy and ACL coexist fine; the policy is what actually grants public read in the post-2023 AWS world.

```hcl
resource "aws_s3_bucket_policy" "app_bucket_public_read" {
  depends_on = [aws_s3_bucket_public_access_block.app_bucket_public_access]
  bucket = aws_s3_bucket.app_bucket.id
  policy = jsonencode({
    Version = "2012-10-17"
    Statement = [{
      Sid       = "PublicReadGetObject"
      Effect    = "Allow"
      Principal = "*"
      Action    = "s3:GetObject"
      Resource  = "${aws_s3_bucket.app_bucket.arn}/*"
    }]
  })
}
```

`depends_on` the public-access-block so the policy isn't rejected by a "block public policy" setting that races with creation.

**Discovered while bringing up `jonathanportarealtor.com`.** A fresh bucket created today returned `403` on anonymous GetObject until a manually-added policy was put in place. The same Cloudflare-fronted bucket then surfaced confusing edge-page behavior during rollout (525/522), but the underlying S3 symptom is the 403 — which is what this module-level fix addresses. Don't over-specify the Cloudflare error mode; the relevant truth is that fresh S3 website buckets need an explicit bucket policy for anonymous reads.

### 2. Portfolio CI workflows (closes #14)

Brings over the four general-purpose, repo-agnostic GitHub Actions files used across the rest of the `JonathanPorta` portfolio:

| File | Purpose |
|---|---|
| `.github/LABELING.md` | Convention docs |
| `.github/workflows/pr-auto-label.yml` | Auto-label PRs by branch name pattern (`jp/b/`, `jp/f/`, `bug/`, `feature/`, etc.) |
| `.github/workflows/pr-labels.yml` | Version label validation (major/minor/patch required for release) |
| `.github/workflows/setup-labels.yml` | One-time label provisioning for new repos |
| `.github/actions/slack-notify/action.yml` | Composite Slack action — rate-limited retry, exponential backoff, header-based `Retry-After` parsing, jq-built JSON payload |

#### Issue #14 status

> - [x] Add branch naming convention labeler for `feat/**`, `fix/**`, etc.

Done via `pr-auto-label.yml`.

> - [ ] Expand the auto releases to include release notes.
> - [ ] Create a GH Release with the release notes from above.

Deferred to a follow-on PR (separate concern from labeling/Slack/policy; involves changing `terraform-publish.yaml` to emit release notes via `release-drafter` or similar).

## Review changes (commit `03f8850`)

In response to in-flight code review:

1. **Label vocabulary aligned.** `.github/workflows/terraform-pr.yaml`'s `check_pull_request_type` job previously required one of `[bug, enhancement, documentation, security]`, but the new auto-labeler applies emoji-prefixed labels. Updated the gate's `one_of` list to accept the full emoji vocabulary so the auto-labeler's output satisfies it.
2. **Slack JSON payload built via `jq -n --arg ...`** instead of heredoc string interpolation — commit messages with quotes/newlines/backslashes can no longer break the payload or inject unintended structure. Falls back with a clear error if `jq` isn't on PATH (it usually is on GH-hosted runners).
3. **Slack `Retry-After` parsed from HTTP header,** not the response body. Per Slack's docs, 429 responses send the wait time in the `Retry-After` header, which the previous code couldn't see. Switched to `curl -D headers_file` and case-insensitive `awk` extraction. Tempfile cleanup added in every case branch.
4. **README documents account/org-level Block Public Access** as a thing that can override this module's bucket-level settings. Includes the `aws s3control get-public-access-block` diagnostic command.
5. **README documents that this module owns the bucket policy.** Don't attach a manual policy; it'll be overwritten on next apply.
6. **README documents the v2 roadmap** — eventual migration to `BucketOwnerEnforced` ownership and removal of ACL resources, since AWS recommends bucket policies over ACLs for modern S3.

Per-consumer extension via an `additional_bucket_policy_statements` variable was considered and deferred — the README warning is sufficient for now; a real consumer needing it can submit a focused PR.

## Backwards-compatibility note

Existing deployments will see **"1 to add"** on next `terraform plan` — the new policy resource. If a manual policy already exists in AWS, the apply will **overwrite** it with the new permissive one (`PublicReadGetObject` only, no writes). Consumers with custom-restricted policies should review the diff before applying.

## Suggested release

**v1.1.0** — additive, no breaking changes for sites that rely on default public-read behavior.

## Test plan

- [ ] Apply this module's new version against a fresh bucket; confirm `aws s3api get-bucket-policy --bucket <name>` returns the new policy
- [ ] Confirm anonymous `curl http://<bucket>.s3-website-<region>.amazonaws.com/index.html` returns 200 (was 403 before)
- [ ] Confirm `pr-auto-label.yml` tags this PR (e.g., `✨ feature`) and that `check_pull_request_type` in `terraform-pr.yaml` accepts that label
- [ ] Confirm the Slack action's jq path renders a valid payload for a multi-line commit message containing quotes
- [ ] (Optional) Force a 429 from Slack and confirm the `Retry-After` header is parsed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)