### PR TITLE
fix: Order object uploads after ownership/public-access settings (fixes first-apply ACL race)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -130,6 +130,17 @@ resource "aws_s3_object" "app_bucket_source" {
   ]))
   acl          = "public-read"
   content_type = local.source_content_types[each.value]
+
+  # Order uploads AFTER the ownership control (re-enables ACLs) and the public-
+  # access block (permits public ACLs). On a brand-new bucket these objects
+  # otherwise upload in parallel and race ahead of those settings, failing with
+  # "AccessControlListNotSupported: The bucket does not allow ACLs" until a
+  # second apply. (Dropping the object ACL entirely — making this depends_on
+  # unnecessary — is the v2 roadmap item; see README.)
+  depends_on = [
+    aws_s3_bucket_ownership_controls.app_bucket_acl_ownership,
+    aws_s3_bucket_public_access_block.app_bucket_public_access,
+  ]
 }
 
 resource "betteruptime_monitor" "this" {


### PR DESCRIPTION
## Problem
On a **brand-new** bucket, the first `apply` fails with:
```
Error: AccessControlListNotSupported: The bucket does not allow ACLs
  with module...aws_s3_object.app_bucket_source[...]
```
A second `apply` succeeds. Root cause: the `aws_s3_object` uploads (`acl = "public-read"`) are created **in parallel** with — and race ahead of — `aws_s3_bucket_ownership_controls` (`ObjectWriter`, which re-enables ACLs) and the public-access block. S3 buckets disable ACLs by default since 2023, so until those settings land, the public-read object ACL is rejected.

## Fix (surgical, non-breaking)
Add an explicit `depends_on` from the objects to the ownership-control + public-access-block resources, so uploads happen *after* ACLs are enabled. 

**Deliberately keeps `acl = "public-read"` as-is.** This avoids:
- any churn on existing deployments (object ACLs unchanged — no diff),
- any Terraform state migration,
- pre-empting the **v2 roadmap** (documented in the README), which removes the object ACL + bucket ACL and switches to `BucketOwnerEnforced` as a deliberate **breaking, major-version** change.

So this is a clean **1.3.1**-style bug fix: it fixes the race only, and leaves the ACL teardown to v2.

> (Earlier revision of this PR removed the object ACL outright — revised to `depends_on` after noting that overlaps with the deferred v2 breaking change.)

Verified against a fresh deploy that previously needed two `apply`s.